### PR TITLE
Sanitize stories names

### DIFF
--- a/lib/clubhouse_workflow.rb
+++ b/lib/clubhouse_workflow.rb
@@ -290,8 +290,8 @@ module ClubhouseWorkflow
 		end
 
 		def sanitizeCharacters(text)
-           text.gsub("\"", "")
-        end
+           		text.gsub("\"", "")
+        	end
 
 	end
 end

--- a/lib/clubhouse_workflow.rb
+++ b/lib/clubhouse_workflow.rb
@@ -134,7 +134,7 @@ module ClubhouseWorkflow
 			stories = stories.map { |s|
 				qa_rejected_label = @info[:qa_rejected_label]
 				blocked_label = @info[:blocked_label]
-				msg = "<#{s['app_url']}|#{s['name']}>"
+				msg = "<#{s['app_url']}|#{sanitizeCharacters(s['name'])}>"
 			}.join(", ")
 		end
 
@@ -288,6 +288,10 @@ module ClubhouseWorkflow
 		def is_released(s)
 			@released_column == s['workflow_state_id']
 		end
+
+		def sanitizeCharacters(text)
+           text.gsub("\"", "")
+        end
 
 	end
 end


### PR DESCRIPTION
Sanitize stories names to avoid illegal character errors when using stories changelog in other commands